### PR TITLE
fix: OraxenFurnitureBreakEvent throwing NPE with null entity

### DIFF
--- a/src/main/java/net/momirealms/customcrops/api/customplugin/oraxen/OraxenHandler.java
+++ b/src/main/java/net/momirealms/customcrops/api/customplugin/oraxen/OraxenHandler.java
@@ -45,6 +45,7 @@ public class OraxenHandler extends Handler {
     @EventHandler
     public void onBreakFurniture(OraxenFurnitureBreakEvent event) {
         Entity entity = event.getBaseEntity();
+        if (entity == null) return;
         switch (entity.getType()) {
             case ITEM_FRAME -> platformManager.onBreakItemFrame(event.getPlayer(), entity, event.getMechanic().getItemID(), event);
             case ITEM_DISPLAY -> platformManager.onBreakItemDisplay(event.getPlayer(), entity, event.getMechanic().getItemID(), event);


### PR DESCRIPTION
Fixes an NPE thrown in the console when Oraxen passes a null entity when Oraxen furniture is broken. 

```
[01:37:41] [Server thread/ERROR]: Could not pass event OraxenFurnitureBreakEvent to CustomCrops v3.0.7
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.getType()" because "entity" is null
	at net.momirealms.customcrops.api.customplugin.oraxen.OraxenHandler.onBreakFurniture(OraxenHandler.java:45) ~[CustomCrops-3.0.7-all.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor986.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:git-PufferfishPlus-56]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:617) ~[pufferfishplus-api-1.19.4-R0.1-entitySNAPSHOT.jar:?]
	at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.onBreakingCustomFurniture(FurnitureListener.java:262) ~[oraxen-1.155.4.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor896.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:git-PufferfishPlus-56]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:617) ~[pufferfishplus-api-1.19.4-R0.1-SNAPSHOT.jar:?]
	at io.th0rgal.oraxen.utils.breaker.BreakerSystem$1$1.accept(BreakerSystem.java:148) ~[oraxen-1.155.4.jar:?]
	at io.th0rgal.oraxen.utils.breaker.BreakerSystem$1$1.accept(BreakerSystem.java:127) ~[oraxen-1.155.4.jar:?]
	at org.bukkit.craftbukkit.v1_19_R3.scheduler.CraftTask.run() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at org.bukkit.craftbukkit.v1_19_R3.scheduler.CraftScheduler.mainThreadHeartbeat() ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at net.minecraft.server.MinecraftServer.b(MinecraftServer.java) ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at net.minecraft.server.dedicated.DedicatedServer.b(DedicatedServer.java) ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at net.minecraft.server.MinecraftServer.a(MinecraftServer.java) ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at net.minecraft.server.MinecraftServer.w(MinecraftServer.java) ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java) ~[pufferfishplus-1.19.4.jar:git-PufferfishPlus-56]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```