### PR TITLE
添加事件 CropGrowEvent

### DIFF
--- a/api/src/main/java/net/momirealms/customcrops/api/event/CropGrowEvent.java
+++ b/api/src/main/java/net/momirealms/customcrops/api/event/CropGrowEvent.java
@@ -1,0 +1,81 @@
+package net.momirealms.customcrops.api.event;
+
+import net.momirealms.customcrops.api.mechanic.item.Crop;
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An async event triggered when crop point changes
+ */
+public class CropGrowEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Crop crop;
+    private final Location location;
+    private final int previousPoint;
+    private final int point;
+
+    public CropGrowEvent(
+            @NotNull Crop crop,
+            @NotNull Location location,
+            int previousPoint,
+            int point
+    ) {
+        super(true);
+        this.crop = crop;
+        this.location = location;
+        this.previousPoint = previousPoint;
+        this.point = point;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    /**
+     * Get the crop
+     *
+     * @return crop
+     */
+    @NotNull
+    public Crop getCrop() {
+        return crop;
+    }
+
+    /**
+     * Get the location where the crop at
+     *
+     * @return location
+     */
+    @NotNull
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Get the old point before update
+     *
+     * @return previousPoint
+     */
+    public int getPreviousPoint() {
+        return previousPoint;
+    }
+
+    /**
+     * Get the new point after update
+     *
+     * @return point
+     */
+    public int getPoint() {
+        return point;
+    }
+}

--- a/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/CChunk.java
+++ b/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/CChunk.java
@@ -18,6 +18,7 @@
 package net.momirealms.customcrops.mechanic.world;
 
 import net.momirealms.customcrops.api.CustomCropsPlugin;
+import net.momirealms.customcrops.api.event.CropGrowEvent;
 import net.momirealms.customcrops.api.mechanic.action.ActionTrigger;
 import net.momirealms.customcrops.api.mechanic.item.Crop;
 import net.momirealms.customcrops.api.mechanic.item.Fertilizer;
@@ -30,6 +31,7 @@ import net.momirealms.customcrops.api.mechanic.world.ChunkPos;
 import net.momirealms.customcrops.api.mechanic.world.CustomCropsBlock;
 import net.momirealms.customcrops.api.mechanic.world.SimpleLocation;
 import net.momirealms.customcrops.api.mechanic.world.level.*;
+import net.momirealms.customcrops.api.util.EventUtils;
 import net.momirealms.customcrops.mechanic.world.block.MemoryPot;
 import net.momirealms.customcrops.mechanic.world.block.MemorySprinkler;
 import net.momirealms.customcrops.scheduler.task.TickTask;
@@ -380,6 +382,9 @@ public class CChunk implements CustomCropsChunk {
         worldCrop.setPoint(x);
         Location bkLoc = location.getBukkitLocation();
         if (bkLoc == null) return;
+        if (previousPoint != x) {
+            EventUtils.fireAndForget(new CropGrowEvent(crop, bkLoc, previousPoint, x));
+        }
         for (int i = previousPoint + 1; i <= x; i++) {
             Crop.Stage stage = crop.getStageByPoint(i);
             if (stage != null) {

--- a/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryCrop.java
+++ b/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryCrop.java
@@ -21,6 +21,7 @@ import com.flowpowered.nbt.CompoundMap;
 import com.flowpowered.nbt.IntTag;
 import com.flowpowered.nbt.StringTag;
 import net.momirealms.customcrops.api.CustomCropsPlugin;
+import net.momirealms.customcrops.api.event.CropGrowEvent;
 import net.momirealms.customcrops.api.mechanic.action.ActionTrigger;
 import net.momirealms.customcrops.api.mechanic.condition.Condition;
 import net.momirealms.customcrops.api.mechanic.condition.DeathConditions;
@@ -34,6 +35,7 @@ import net.momirealms.customcrops.api.mechanic.world.SimpleLocation;
 import net.momirealms.customcrops.api.mechanic.world.level.AbstractCustomCropsBlock;
 import net.momirealms.customcrops.api.mechanic.world.level.WorldCrop;
 import net.momirealms.customcrops.api.mechanic.world.level.WorldPot;
+import net.momirealms.customcrops.api.util.EventUtils;
 import net.momirealms.customcrops.api.util.LogUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -163,6 +165,9 @@ public class MemoryCrop extends AbstractCustomCropsBlock implements WorldCrop {
 
         int x = Math.min(previous + point, crop.getMaxPoints());
         setPoint(x);
+        if (previous != x) {
+            EventUtils.fireAndForget(new CropGrowEvent(crop, bukkitLocation, previous, x));
+        }
         String pre = crop.getStageItemByPoint(previous);
         String after = crop.getStageItemByPoint(x);
 


### PR DESCRIPTION
想监听作物生长，结果没找到相应事件或者接口，只找到跟生长点数绑定的 ActionTrigger，想着加个事件可能更方便其它插件监听。